### PR TITLE
Fix `git clone` URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This script has nothing to do with NRK!
 
 ## Install
 ```bash
-git clone https://github.com/odinuge/nrk-tv-downloader/ --recursive
+git clone https://github.com/odinuge/nrk-tv-downloader --recursive
 ```
 
 ### Subtitles


### PR DESCRIPTION
The trailing slash in the URI prevents me from cloning the repo. I'm using MacOS; and the current command (with the slash in the URI) throws an `ERROR: Repository not found.`. However, when removing the trailing slash in the URI, the command works just fine.