### PR TITLE
Added the "-l" flag to download the latest episode

### DIFF
--- a/nrk-tv-downloader.sh
+++ b/nrk-tv-downloader.sh
@@ -131,6 +131,7 @@ function usage() {
 	echo -e "\nOptions:"
 	echo -e "\t -a download all episodes, in all seasons."
 	echo -e "\t -s download all episodes in season"
+    echo -e "\t -l download all episodes in season"
 	echo -e "\t -n skip files that exists"
 	echo -e "\t -d dry run - list what is possible to download"
 	echo -e "\t -u do not download subtitles"
@@ -584,8 +585,56 @@ function program() {
 		# Download the stream
 		download "$stream" "$dl_file" "$subtitle_file"
 	done
-
 }
+
+
+function program_latest() {
+    # This function find the latest available episode of the latest season,
+    # and downloads the episode
+    local url="$1"
+
+	local html=$($CURL_ -L "$url")
+	local program_id
+	program_id=$(echo "$html" | sed -n "s/^.*data-program-id=\"\([^\"]*\).*$/\1/p")
+
+	if [ -z "$program_id" ]; then
+		program_id=$(echo "$html" | sed -n "s/^.*nrk:program-id\" content=\"\([^\"]*\).*$/\1/p")
+	fi
+
+	# Fetch the info with the v8-API
+	local v8=$($CURL_ "https://psapi-we.nrk.no/mediaelement/${program_id}")
+	local series_id=$(parsejson "$v8" "seriesId")
+    if [ -z "$series_id" ]; then
+        echo "Unable to find series"
+        return
+    fi
+
+    local series_data=$($CURL_ \
+        "https://psapi.nrk.no/tv/catalog/series/${series_id}")
+    local last_season=$(echo "$series_data" | jq '._links.seasons[-1]')
+    local last_season_nr=$(echo "$last_season" | jq -r '.name')
+    if [ -z "$last_season_nr" ]; then
+        echo "Unable to find season for series: ${series_id}"
+        return
+    fi
+    local last_season_href=$(echo "$last_season" | jq -r '.href')
+
+    local url2="https://psapi-we.nrk.no${last_season_href}"
+    local season_data=$($CURL_ "https://psapi-we.nrk.no${last_season_href}")
+
+    local last_available_series=$(echo "$season_data" | jq '._embedded.episodes | map(. | select(.availability.status=="available")) | .[-1]')
+    local last_episode_seqno=$(echo "$last_available_series" | jq '.sequenceNumber')
+    local last_episode_url="${url}/sesong/${last_season_nr}/episode/${last_episode_seqno}"
+
+    if [ -z "$last_episode_seqno" ]; then
+        echo "Unable to find episode"
+        return
+    fi
+
+    # Download last episode here
+    program $last_episode_url
+}
+
 function main() {
 	DL_ALL=false
 	IS_RADIO=false
@@ -594,7 +643,7 @@ function main() {
 	# Main part of script
 	OPTIND=1
 
-	while getopts "hasnudefqt:" opt; do
+	while getopts "haslnudefqt:" opt; do
 		case "$opt" in
 		h)
 			usage
@@ -633,6 +682,9 @@ function main() {
 			DL_ALL=true
 			SEASON=true
 			;;
+        l)
+            DL_LATEST=true
+            ;;
 		*) ;;
 		esac
 	done
@@ -651,8 +703,11 @@ function main() {
 			if [[ "$var" == *radio.nrk.no* ]]; then
 				IS_RADIO=true
 			fi
+
 			if $DL_ALL; then
 				program_all "$var"
+            elif $DL_LATEST; then
+                program_latest "$var"
 			else
 				program "$var"
 			fi

--- a/nrk-tv-downloader.sh
+++ b/nrk-tv-downloader.sh
@@ -618,10 +618,7 @@ function program_latest() {
         return
     fi
     local last_season_href=$(echo "$last_season" | jq -r '.href')
-
-    local url2="https://psapi-we.nrk.no${last_season_href}"
     local season_data=$($CURL_ "https://psapi-we.nrk.no${last_season_href}")
-
     local last_available_series=$(echo "$season_data" | jq '._embedded.episodes | map(. | select(.availability.status=="available")) | .[-1]')
     local last_episode_seqno=$(echo "$last_available_series" | jq '.sequenceNumber')
     local last_episode_url="${url}/sesong/${last_season_nr}/episode/${last_episode_seqno}"
@@ -632,7 +629,7 @@ function program_latest() {
     fi
 
     # Download last episode here
-    program $last_episode_url
+    program "$last_episode_url"
 }
 
 function main() {

--- a/nrk-tv-downloader.sh
+++ b/nrk-tv-downloader.sh
@@ -131,7 +131,7 @@ function usage() {
 	echo -e "\nOptions:"
 	echo -e "\t -a download all episodes, in all seasons."
 	echo -e "\t -s download all episodes in season"
-    echo -e "\t -l download all episodes in season"
+	echo -e "\t -l download all episodes in season"
 	echo -e "\t -n skip files that exists"
 	echo -e "\t -d dry run - list what is possible to download"
 	echo -e "\t -u do not download subtitles"
@@ -587,11 +587,10 @@ function program() {
 	done
 }
 
-
 function program_latest() {
-    # This function find the latest available episode of the latest season,
-    # and downloads the episode
-    local url="$1"
+	# This function find the latest available episode of the latest season,
+	# and downloads the episode
+	local url="$1"
 
 	local html=$($CURL_ -L "$url")
 	local program_id
@@ -604,32 +603,32 @@ function program_latest() {
 	# Fetch the info with the v8-API
 	local v8=$($CURL_ "https://psapi-we.nrk.no/mediaelement/${program_id}")
 	local series_id=$(parsejson "$v8" "seriesId")
-    if [ -z "$series_id" ]; then
-        echo "Unable to find series"
-        return
-    fi
+	if [ -z "$series_id" ]; then
+		echo "Unable to find series"
+		return
+	fi
 
-    local series_data=$($CURL_ \
-        "https://psapi.nrk.no/tv/catalog/series/${series_id}")
-    local last_season=$(echo "$series_data" | jq '._links.seasons[-1]')
-    local last_season_nr=$(echo "$last_season" | jq -r '.name')
-    if [ -z "$last_season_nr" ]; then
-        echo "Unable to find season for series: ${series_id}"
-        return
-    fi
-    local last_season_href=$(echo "$last_season" | jq -r '.href')
-    local season_data=$($CURL_ "https://psapi-we.nrk.no${last_season_href}")
-    local last_available_series=$(echo "$season_data" | jq '._embedded.episodes | map(. | select(.availability.status=="available")) | .[-1]')
-    local last_episode_seqno=$(echo "$last_available_series" | jq '.sequenceNumber')
-    local last_episode_url="${url}/sesong/${last_season_nr}/episode/${last_episode_seqno}"
+	local series_data=$($CURL_ \
+		"https://psapi.nrk.no/tv/catalog/series/${series_id}")
+	local last_season=$(echo "$series_data" | jq '._links.seasons[-1]')
+	local last_season_nr=$(echo "$last_season" | jq -r '.name')
+	if [ -z "$last_season_nr" ]; then
+		echo "Unable to find season for series: ${series_id}"
+		return
+	fi
+	local last_season_href=$(echo "$last_season" | jq -r '.href')
+	local season_data=$($CURL_ "https://psapi-we.nrk.no${last_season_href}")
+	local last_available_series=$(echo "$season_data" | jq '._embedded.episodes | map(. | select(.availability.status=="available")) | .[-1]')
+	local last_episode_seqno=$(echo "$last_available_series" | jq '.sequenceNumber')
+	local last_episode_url="${url}/sesong/${last_season_nr}/episode/${last_episode_seqno}"
 
-    if [ -z "$last_episode_seqno" ]; then
-        echo "Unable to find episode"
-        return
-    fi
+	if [ -z "$last_episode_seqno" ]; then
+		echo "Unable to find episode"
+		return
+	fi
 
-    # Download last episode here
-    program "$last_episode_url"
+	# Download last episode here
+	program "$last_episode_url"
 }
 
 function main() {
@@ -679,9 +678,9 @@ function main() {
 			DL_ALL=true
 			SEASON=true
 			;;
-        l)
-            DL_LATEST=true
-            ;;
+		l)
+			DL_LATEST=true
+			;;
 		*) ;;
 		esac
 	done
@@ -703,8 +702,8 @@ function main() {
 
 			if $DL_ALL; then
 				program_all "$var"
-            elif $DL_LATEST; then
-                program_latest "$var"
+			elif $DL_LATEST; then
+				program_latest "$var"
 			else
 				program "$var"
 			fi


### PR DESCRIPTION
I think this will fix the issue #36.
This new feature identifies the latest available episode for the last season available.

Tested for the NRK series:
    - ./nrk-tv-downloader.sh -l https://tv.nrk.no/serie/foerstegangstjenesten
    - ./nrk-tv-downloader.sh -l https://tv.nrk.no/serie/113

Tested on my Ubuntu 20.04 LTS.